### PR TITLE
feat(): add custom ns labels/annotations

### DIFF
--- a/pkg/controller/v1alpha1/cluster_types.go
+++ b/pkg/controller/v1alpha1/cluster_types.go
@@ -57,6 +57,9 @@ type ClusterSpec struct {
 	NetworkInterface string `json:"networkInterface,omitempty"`
 	//put in an object
 	ClusterProperty ClusterProperty `json:"clusterProperty,omitempty"`
+	// EnableAutoEviction is a flag to enable auto eviction feature for the given cluster
+	EnableAutoEviction bool `json:"enableAutoEviction,omitempty"`
+	RequeueOnFailure   bool `json:"requeueOnFailure,omitempty"`
 }
 
 type ClusterProperty struct {
@@ -92,6 +95,8 @@ type GeoLocation struct {
 
 // Monitoring defines the field of ClusterSpec
 type Monitoring struct {
+	// GrafanaDashboardBaseURL is the base URL for the grafana dashboard
+	GrafanaDashboardBaseURL string `json:"grafanaDashboardBaseURL,omitempty"`
 	//KubernetesDashboard contains the information regarding Kubernetes Monitoring Dashboard
 	KubernetesDashboard KubernetesDashboard `json:"kubernetesDashboard,omitempty"`
 }
@@ -131,8 +136,17 @@ type ClusterStatus struct {
 
 	// VCPURestriction is the restriction on the cluster disabling the creation of new pods
 	VCPURestriction *VCPURestriction `json:"vCPURestriction,omitempty"`
+
+	//NamespaceConfig is the set of user defined labels/annotations to be applied to any namespace created under the cluster CR
+	NamespaceConfig NamespaceConfig `json:"namespaceConfig,omitempty"`
 }
 
+type NamespaceConfig struct {
+	// NamespaceLabels is the set of user defined labels to be applied to any namespace created under the cluster CR
+	NamespaceLabels map[string]string `json:"namespaceLabels,omitempty"`
+	// NamespaceAnnotations is the set of user defined annotations to be applied to any namespace created under the cluster CR
+	NamespaceAnnotations map[string]string `json:"namespaceAnnotations,omitempty"`
+}
 type VCPURestriction struct {
 	// EnforceRestrictions is the flag to check if the cluster is restricted
 	EnforceRestrictions bool `json:"enforceRestrictions,omitempty"`


### PR DESCRIPTION
adding field NamespaceConfig
which has fields
1. NamespaceLabels
2. NamespaceAnnotations

These above fields will be used in ClusterCR Status to store the user defined custom namespace labels and annotations

Sync with ent-egs apis changes for additional fields added

<!--
Type of change: Title of the PR should clearly mention which type of PR is this, you can select any of the below mentioned types:

- docs() - The PR contains Documentation ONLY changes. 
- feat() - The PR contains new feature/enhancements.
- fix() - The PR contains a bug fix.
- chore() - Development changes related to the build system (involving scripts, configurations or tools) and package dependencies.
- test() - Development changes related to tests.
- perf() - Changes related to performance improvements.

Example Title: 
feat(): New field addition for Cluster CRD 
-->

# Description
<!--
Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
-->

Fixes #

## How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
<!--test-cases
- [ ] Test case A
- [ ] Test case B
-->

## Checklist:

* [ ] The title of the PR states what changed and the related issues number (used for the release note).
* [ ] Does this PR requires documentation updates?
* [ ] I've updated documentation as required by this PR.
* [ ] I have performed a self-review of my own code.
* [ ] I have commented my code, particularly in hard-to-understand areas.
* [ ] I have tested it for all user roles.
* [ ] I have added all the required unit test cases.

## Does this PR introduce a breaking change for other components like kubeslice-controller, worker-operator?
<!--
If NO, leave the release-note block blank.
If YES, a release note is required:
Enter your extended release note in the block below. If the PR requires additional manual action from users switching to the new version, include the string "action-required".

-->
```release-note

```

